### PR TITLE
fix: use aspect_flag when calling imageview_create_info

### DIFF
--- a/tutorial/04_textures_and_engine_architecture/images.odin
+++ b/tutorial/04_textures_and_engine_architecture/images.odin
@@ -138,7 +138,7 @@ create_image_default :: proc(
 	}
 
 	// Build a image-view for the draw image to use for rendering
-	view_info := imageview_create_info(new_image.image_format, new_image.image, {.COLOR})
+	view_info := imageview_create_info(new_image.image_format, new_image.image, aspect_flag)
 
 	vk_check(vk.CreateImageView(self.vk_device, &view_info, nil, &new_image.image_view)) or_return
 	defer if !ok {

--- a/tutorial/05_scene_graph/images.odin
+++ b/tutorial/05_scene_graph/images.odin
@@ -138,7 +138,7 @@ create_image_default :: proc(
 	}
 
 	// Build a image-view for the draw image to use for rendering
-	view_info := imageview_create_info(new_image.image_format, new_image.image, {.COLOR})
+	view_info := imageview_create_info(new_image.image_format, new_image.image, aspect_flag)
 
 	vk_check(vk.CreateImageView(self.vk_device, &view_info, nil, &new_image.image_view)) or_return
 	defer if !ok {

--- a/website/docs/04-textures-and-engine-architecture/02-textures.md
+++ b/website/docs/04-textures-and-engine-architecture/02-textures.md
@@ -123,7 +123,7 @@ create_image_default :: proc(
     }
 
     // Build a image-view for the draw image to use for rendering
-    view_info := imageview_create_info(new_image.image_format, new_image.image, {.COLOR})
+    view_info := imageview_create_info(new_image.image_format, new_image.image, aspect_flag)
 
     vk_check(vk.CreateImageView(self.vk_device, &view_info, nil, &new_image.image_view)) or_return
     defer if !ok {


### PR DESCRIPTION
Hey, you probably forgot to use `aspect_flag` when calling `imageview_create_info`.

BTW, thanks for rewriting vk-guide in Odin! I learnt a couple of things I didn't know about Odin, great work!