### PR TITLE
fix: correct cgltf make command in linux

### DIFF
--- a/website/docs/03-graphics-pipeline/04-mesh-loading.md
+++ b/website/docs/03-graphics-pipeline/04-mesh-loading.md
@@ -31,7 +31,7 @@ Fortunately, Odin includes a `Makefile` script to simplify this process, located
 system:
 
 ```bash
-make linux   # For Linux
+make unix   # For Linux
 make darwin  # For macOS
 ```
 


### PR DESCRIPTION
The build command for Linux is `make unix`.
Alternatively, you can just run `make`, as the Makefile detects if you're on Darwin or not and runs the appropriate job.