### PR TITLE
fix: correct engine rectangle usage

### DIFF
--- a/website/docs/03-graphics-pipeline/03-mesh-buffers.md
+++ b/website/docs/03-graphics-pipeline/03-mesh-buffers.md
@@ -790,11 +790,11 @@ engine_init_default_data :: proc(self: ^Engine) -> (ok: bool) {
     }
     // odinfmt: enable
 
-    rectangle := upload_mesh(self, rect_indices[:], rect_vertices[:]) or_return
+    self.rectangle := upload_mesh(self, rect_indices[:], rect_vertices[:]) or_return
 
     // Delete the rectangle data on engine shutdown
-    deletion_queue_push(&self.main_deletion_queue, &rectangle.index_buffer)
-    deletion_queue_push(&self.main_deletion_queue, &rectangle.vertex_buffer)
+    deletion_queue_push(&self.main_deletion_queue, self.rectangle.index_buffer)
+    deletion_queue_push(&self.main_deletion_queue, self.rectangle.vertex_buffer)
 
     return true
 }


### PR DESCRIPTION
The current code creates a new rectangle rather than using the engine's rectangle, adds references to its buffer to the deletion queue, then deletes the rectangle when the procedure returns.

First, this causes a compiler error. The deletion queue can handle an Allocated_Buffer, but not a pointer to one. We should queue the buffers by value, instead.

Next, if we don't set the engine's rectangle property, we'll get a hang and then a crash with a few Validation Layer errors. This is because we're trying to draw an uninitialized index. Using `self.rectangle` instead of `rectangle` solves this issue.

<details>
<summary>Validation Layer Errors</summary>
```sh
[INFO ] --- Entering main loop...
[ERROR] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkCmdBindIndexBuffer(): buffer is VK_NULL_HANDLE.
The Vulkan spec states: If the maintenance6 feature is not enabled, buffer must not be VK_NULL_HANDLE (https://docs.vulkan.org/spec/latest/chapters/drawing
.html#VUID-vkCmdBindIndexBuffer-None-09493)
[ERROR] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkCmdDrawIndexed(): no vkCmdBindIndexBuffer call has bound an index buffer to this command buffer 
prior to this indexed draw.
The Vulkan spec states: If the maintenance6 feature is not enabled, a valid index buffer must be bound (https://docs.vulkan.org/spec/latest/chapters/drawin
g.html#VUID-vkCmdDrawIndexed-None-07312)
[ERROR] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkCmdBindIndexBuffer(): buffer is VK_NULL_HANDLE.
The Vulkan spec states: If the maintenance6 feature is not enabled, buffer must not be VK_NULL_HANDLE (https://docs.vulkan.org/spec/latest/chapters/drawing
.html#VUID-vkCmdBindIndexBuffer-None-09493)
[ERROR] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkCmdDrawIndexed(): no vkCmdBindIndexBuffer call has bound an index buffer to this command buffer 
prior to this indexed draw.
The Vulkan spec states: If the maintenance6 feature is not enabled, a valid index buffer must be bound (https://docs.vulkan.org/spec/latest/chapters/drawin
g.html#VUID-vkCmdDrawIndexed-None-07312)
[ERROR] --- [Vulkan Error] Detected Vulkan error: TIMEOUT
```
</details>