### PR TITLE
fix: add version 11 features to make validation errors go away

### DIFF
--- a/tutorial/01_initializing_vulkan/engine.odin
+++ b/tutorial/01_initializing_vulkan/engine.odin
@@ -199,6 +199,11 @@ engine_init_vulkan :: proc(self: ^Engine) -> (ok: bool) {
 		vkb.destroy_surface(self.vkb.instance, self.vk_surface)
 	}
 
+	// Vulkan 1.1 features
+	features_11 := vk.PhysicalDeviceVulkan11Features {
+		shaderDrawParameters = true,
+	}
+
 	// Vulkan 1.2 features
 	features_12 := vk.PhysicalDeviceVulkan12Features {
 		// Allows shaders to directly access buffer memory using GPU addresses
@@ -224,6 +229,7 @@ engine_init_vulkan :: proc(self: ^Engine) -> (ok: bool) {
 	vkb.selector_set_minimum_version(&selector, vk.API_VERSION_1_3)
 	vkb.selector_set_required_features_13(&selector, features_13)
 	vkb.selector_set_required_features_12(&selector, features_12)
+	vkb.selector_set_required_features_11(&selector, features_11)
 	vkb.selector_set_surface(&selector, self.vk_surface)
 
 	self.vkb.physical_device = vkb.select_physical_device(&selector) or_return

--- a/tutorial/02_drawing_with_compute/engine.odin
+++ b/tutorial/02_drawing_with_compute/engine.odin
@@ -247,6 +247,11 @@ engine_init_vulkan :: proc(self: ^Engine) -> (ok: bool) {
 		vkb.destroy_surface(self.vkb.instance, self.vk_surface)
 	}
 
+	// Vulkan 1.1 features
+	features_11 := vk.PhysicalDeviceVulkan11Features {
+		shaderDrawParameters = true,
+	}
+
 	// Vulkan 1.2 features
 	features_12 := vk.PhysicalDeviceVulkan12Features {
 		// Allows shaders to directly access buffer memory using GPU addresses
@@ -272,6 +277,7 @@ engine_init_vulkan :: proc(self: ^Engine) -> (ok: bool) {
 	vkb.selector_set_minimum_version(&selector, vk.API_VERSION_1_3)
 	vkb.selector_set_required_features_13(&selector, features_13)
 	vkb.selector_set_required_features_12(&selector, features_12)
+	vkb.selector_set_required_features_11(&selector, features_11)
 	vkb.selector_set_surface(&selector, self.vk_surface)
 
 	self.vkb.physical_device = vkb.select_physical_device(&selector) or_return

--- a/tutorial/03_graphics_pipelines/init.odin
+++ b/tutorial/03_graphics_pipelines/init.odin
@@ -163,6 +163,11 @@ engine_init_vulkan :: proc(self: ^Engine) -> (ok: bool) {
 		vkb.destroy_surface(self.vkb.instance, self.vk_surface)
 	}
 
+	// Vulkan 1.1 features
+	features_11 := vk.PhysicalDeviceVulkan11Features {
+		shaderDrawParameters = true,
+	}
+
 	// Vulkan 1.2 features
 	features_12 := vk.PhysicalDeviceVulkan12Features {
 		// Allows shaders to directly access buffer memory using GPU addresses
@@ -188,6 +193,7 @@ engine_init_vulkan :: proc(self: ^Engine) -> (ok: bool) {
 	vkb.selector_set_minimum_version(&selector, vk.API_VERSION_1_3)
 	vkb.selector_set_required_features_13(&selector, features_13)
 	vkb.selector_set_required_features_12(&selector, features_12)
+	vkb.selector_set_required_features_11(&selector, features_11)
 	vkb.selector_set_surface(&selector, self.vk_surface)
 
 	self.vkb.physical_device = vkb.select_physical_device(&selector) or_return

--- a/tutorial/04_textures_and_engine_architecture/init.odin
+++ b/tutorial/04_textures_and_engine_architecture/init.odin
@@ -170,6 +170,11 @@ engine_init_vulkan :: proc(self: ^Engine) -> (ok: bool) {
 		vkb.destroy_surface(self.vkb.instance, self.vk_surface)
 	}
 
+	// Vulkan 1.1 features
+	features_11 := vk.PhysicalDeviceVulkan11Features {
+		shaderDrawParameters = true,
+	}
+
 	// Vulkan 1.2 features
 	features_12 := vk.PhysicalDeviceVulkan12Features {
 		// Allows shaders to directly access buffer memory using GPU addresses
@@ -195,6 +200,7 @@ engine_init_vulkan :: proc(self: ^Engine) -> (ok: bool) {
 	vkb.selector_set_minimum_version(&selector, vk.API_VERSION_1_3)
 	vkb.selector_set_required_features_13(&selector, features_13)
 	vkb.selector_set_required_features_12(&selector, features_12)
+	vkb.selector_set_required_features_11(&selector, features_11)
 	vkb.selector_set_surface(&selector, self.vk_surface)
 
 	self.vkb.physical_device = vkb.select_physical_device(&selector) or_return

--- a/tutorial/05_scene_graph/init.odin
+++ b/tutorial/05_scene_graph/init.odin
@@ -168,6 +168,11 @@ engine_init_vulkan :: proc(self: ^Engine) -> (ok: bool) {
 		vkb.destroy_surface(self.vkb.instance, self.vk_surface)
 	}
 
+	// Vulkan 1.1 features
+	features_11 := vk.PhysicalDeviceVulkan11Features {
+		shaderDrawParameters = true,
+	}
+
 	// Vulkan 1.2 features
 	features_12 := vk.PhysicalDeviceVulkan12Features {
 		// Allows shaders to directly access buffer memory using GPU addresses
@@ -193,6 +198,7 @@ engine_init_vulkan :: proc(self: ^Engine) -> (ok: bool) {
 	vkb.selector_set_minimum_version(&selector, vk.API_VERSION_1_3)
 	vkb.selector_set_required_features_13(&selector, features_13)
 	vkb.selector_set_required_features_12(&selector, features_12)
+	vkb.selector_set_required_features_11(&selector, features_11)
 	vkb.selector_set_surface(&selector, self.vk_surface)
 
 	self.vkb.physical_device = vkb.select_physical_device(&selector) or_return


### PR DESCRIPTION
When running through the guide, I had these validation errors:

<details>
<summary>Validation Layer Errors</summary>
<pre><code>
[ERROR] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkCreateShaderModule(): SPIR-V Capability DrawParameters was declared, but one of the following re
quirements is required (VkPhysicalDeviceVulkan11Features::shaderDrawParameters OR VK_KHR_shader_draw_parameters).
The Vulkan spec states: If pCode is a pointer to SPIR-V code, and pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of 
the corresponding requirements must be satisfied (https://docs.vulkan.org/spec/latest/chapters/shaders.html#VUID-VkShaderModuleCreateInfo-pCode-08740)
[ERROR] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkCreateShaderModule(): SPIR-V Capability DrawParameters was declared, but one of the following re
quirements is required (VkPhysicalDeviceVulkan11Features::shaderDrawParameters OR VK_KHR_shader_draw_parameters).
The Vulkan spec states: If pCode is a pointer to SPIR-V code, and pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of 
the corresponding requirements must be satisfied (https://docs.vulkan.org/spec/latest/chapters/shaders.html#VUID-VkShaderModuleCreateInfo-pCode-08740)
[INFO ] --- Entering main loop...
</code></pre>
</details>

To be honest, I'm not sure _why_ these errors were popping up. As far as I can tell, none of the shaders in this project use the variables that the `shaderDrawParameters` feature provides. Blame it on the AMD drivers, maybe `¯\_(ツ)_/¯`. Nonetheless, adding that feature makes the errors go away.