### PR TITLE
fix: create semaphores for swapchain images

### DIFF
--- a/tutorial/01_initializing_vulkan/engine.odin
+++ b/tutorial/01_initializing_vulkan/engine.odin
@@ -269,6 +269,15 @@ engine_create_swapchain :: proc(self: ^Engine, extent: vk.Extent2D) -> (ok: bool
 	self.swapchain_images = vkb.swapchain_get_images(self.vkb.swapchain) or_return
 	self.swapchain_image_views = vkb.swapchain_get_image_views(self.vkb.swapchain) or_return
 	self.swapchain_image_semaphores = make([]vk.Semaphore, len(self.swapchain_images))[:]
+	defer if !ok do delete(self.swapchain_image_semaphores)
+
+	// These need to be created here so that they are recreated when we resize.
+	semaphore_create_info := semaphore_create_info()
+	for &semaphore in self.swapchain_image_semaphores {
+		vk_check(
+			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
+		) or_return
+	}
 
 	return true
 }
@@ -347,13 +356,6 @@ engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
 				nil,
 				&frame.swapchain_semaphore,
 			),
-		) or_return
-	}
-
-	// Create a semaphore for each image in the swapchain.
-	for &semaphore in self.swapchain_image_semaphores {
-		vk_check(
-			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
 		) or_return
 	}
 

--- a/tutorial/01_initializing_vulkan/engine.odin
+++ b/tutorial/01_initializing_vulkan/engine.odin
@@ -19,7 +19,6 @@ Frame_Data :: struct {
 	command_pool:        vk.CommandPool,
 	main_command_buffer: vk.CommandBuffer,
 	swapchain_semaphore: vk.Semaphore,
-	render_semaphore:    vk.Semaphore,
 	render_fence:        vk.Fence,
 }
 
@@ -118,7 +117,6 @@ engine_cleanup :: proc(self: ^Engine) {
 
 		// Destroy sync objects
 		vk.DestroyFence(self.vk_device, frame.render_fence, nil)
-		vk.DestroySemaphore(self.vk_device, frame.render_semaphore, nil)
 		vk.DestroySemaphore(self.vk_device, frame.swapchain_semaphore, nil)
 	}
 

--- a/tutorial/02_drawing_with_compute/engine.odin
+++ b/tutorial/02_drawing_with_compute/engine.odin
@@ -950,6 +950,15 @@ engine_draw :: proc(self: ^Engine) -> (ok: bool) {
 	// This will put the image we just rendered to into the visible window. we want to wait on
 	// the `ready_for_present_semaphore` for that, as its necessary that drawing commands
 	// have finished before the image is displayed to the user.
+	present_info := vk.PresentInfoKHR {
+		sType              = .PRESENT_INFO_KHR,
+		pSwapchains        = &self.vk_swapchain,
+		swapchainCount     = 1,
+		pWaitSemaphores    = &ready_for_present_semaphore,
+		waitSemaphoreCount = 1,
+		pImageIndices      = &swapchain_image_index,
+	}
+
 	vk_check(vk.QueuePresentKHR(self.graphics_queue, &present_info)) or_return
 
 	// Increase the number of frames drawn

--- a/tutorial/02_drawing_with_compute/engine.odin
+++ b/tutorial/02_drawing_with_compute/engine.odin
@@ -24,7 +24,6 @@ Frame_Data :: struct {
 	command_pool:          vk.CommandPool,
 	main_command_buffer:   vk.CommandBuffer,
 	swapchain_semaphore:   vk.Semaphore,
-	render_semaphore:      vk.Semaphore,
 	swapchain_image_index: u32,
 	render_fence:          vk.Fence,
 	deletion_queue:        Deletion_Queue,
@@ -76,6 +75,7 @@ Engine :: struct {
 	swapchain_extent:             vk.Extent2D,
 	swapchain_images:             []vk.Image,
 	swapchain_image_views:        []vk.ImageView,
+	swapchain_image_semaphores:   []vk.Semaphore,
 
 	// Frame management
 	frames:                       [FRAME_OVERLAP]Frame_Data,
@@ -174,7 +174,6 @@ engine_cleanup :: proc(self: ^Engine) {
 
 		// Destroy sync objects
 		vk.DestroyFence(self.vk_device, frame.render_fence, nil)
-		vk.DestroySemaphore(self.vk_device, frame.render_semaphore, nil)
 		vk.DestroySemaphore(self.vk_device, frame.swapchain_semaphore, nil)
 
 		// Flush and destroy the peer frame deletion queue
@@ -341,6 +340,7 @@ engine_create_swapchain :: proc(self: ^Engine, width, height: u32) -> (ok: bool)
 
 	self.swapchain_images = vkb.swapchain_get_images(self.vkb.swapchain) or_return
 	self.swapchain_image_views = vkb.swapchain_get_image_views(self.vkb.swapchain) or_return
+	self.swapchain_image_semaphores = make([]vk.Semaphore, len(self.swapchain_images))[:]
 
 	return true
 }
@@ -463,10 +463,9 @@ engine_init_commands :: proc(self: ^Engine) -> (ok: bool) {
 }
 
 engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
-	// Create synchronization structures, one fence to control when the gpu has
-	// finished rendering the frame, and 2 semaphores to sincronize rendering with
-	// swapchain. We want the fence to start signalled so we can wait on it on the
-	// first frame
+	// Create synchronization structures, one fence to control when the gpu has finished
+	// rendering the frame, and a semaphore to synchronize rendering with swapchain. We want
+	// the fence to start signaled so we can wait on it on the first frame.
 	fence_create_info := fence_create_info({.SIGNALED})
 	semaphore_create_info := semaphore_create_info()
 
@@ -483,19 +482,14 @@ engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
 				&self.frames[i].swapchain_semaphore,
 			),
 		) or_return
-		vk_check(
-			vk.CreateSemaphore(
-				self.vk_device,
-				&semaphore_create_info,
-				nil,
-				&self.frames[i].render_semaphore,
-			),
-		) or_return
 	}
 
-	// vk_check(vk.CreateFence(self.vk_device, &fence_create_info, nil, &self.im_fence)) or_return
-
-	// deletion_queue_push(&self.main_deletion_queue, self.im_fence)
+	// Create a semaphore for each image in the swapchain.
+	for &semaphore in self.swapchain_image_semaphores {
+		vk_check(
+			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
+		) or_return
+	}
 
 	return true
 }
@@ -657,34 +651,6 @@ engine_init_pipelines :: proc(self: ^Engine) -> (ok: bool) {
 	engine_init_background_pipelines(self) or_return
 	return true
 }
-
-// Immediate_Proc :: #type proc(engine: ^Engine, cmd: vk.CommandBuffer)
-
-// engine_immediate_submit :: proc(self: ^Engine, im_proc: Immediate_Proc) -> (ok: bool) {
-// 	vk_check(vk.ResetFences(self.vk_device, 1, &self.im_fence)) or_return
-// 	vk_check(vk.ResetCommandBuffer(self.im_command_buffer, {})) or_return
-
-// 	cmd := self.im_command_buffer
-
-// 	cmd_begin_info := command_buffer_begin_info({.ONE_TIME_SUBMIT})
-
-// 	vk_check(vk.BeginCommandBuffer(cmd, &cmd_begin_info)) or_return
-
-// 	im_proc(self, cmd)
-
-// 	vk_check(vk.EndCommandBuffer(cmd)) or_return
-
-// 	cmd_info := command_buffer_submit_info(cmd)
-// 	submit_info := submit_info(&cmd_info, nil, nil)
-
-// 	// Submit command buffer to the queue and execute it.
-// 	//  `render_fence` will now block until the graphic commands finish execution
-// 	vk_check(vk.QueueSubmit2(self.graphics_queue, 1, &submit_info, self.im_fence)) or_return
-
-// 	vk_check(vk.WaitForFences(self.vk_device, 1, &self.im_fence, true, 9999999999)) or_return
-
-// 	return true
-// }
 
 engine_init_imgui :: proc(self: ^Engine) -> (ok: bool) {
 	im.CHECKVERSION()
@@ -964,33 +930,26 @@ engine_draw :: proc(self: ^Engine) -> (ok: bool) {
 
 	// Prepare the submission to the queue. we want to wait on the
 	// `swapchain_semaphore`, as that semaphore is signaled when the swapchain is
-	// ready we will signal the `render_semaphore`, to signal that rendering has
-	// finished
+	// ready. We will signal the `ready_for_present_semaphore`, to signal that
+	// rendering has finished.
+
+	ready_for_present_semaphore := self.swapchain_image_semaphores[frame.swapchain_image_index]
 
 	cmd_info := command_buffer_submit_info(cmd)
-	signal_info := semaphore_submit_info({.ALL_GRAPHICS}, frame.render_semaphore)
+	signal_info := semaphore_submit_info({.ALL_GRAPHICS}, ready_for_present_semaphore)
 	wait_info := semaphore_submit_info({.COLOR_ATTACHMENT_OUTPUT_KHR}, frame.swapchain_semaphore)
 
 	submit := submit_info(&cmd_info, &signal_info, &wait_info)
 
-	// Submit command buffer to the queue and execute it. _renderFence will now
-	// block until the graphic commands finish execution
+	// Submit command buffer to the queue and execute it. `render_fence` will now
+	// block until the graphic commands finish execution.
 	vk_check(vk.QueueSubmit2(self.graphics_queue, 1, &submit, frame.render_fence)) or_return
 
 	// Prepare present
 	//
-	// this will put the image we just rendered to into the visible window. we
-	// want to wait on the `render_semaphore` for that, as its necessary that
-	// drawing commands have finished before the image is displayed to the user
-	present_info := vk.PresentInfoKHR {
-		sType              = .PRESENT_INFO_KHR,
-		pSwapchains        = &self.vk_swapchain,
-		swapchainCount     = 1,
-		pWaitSemaphores    = &frame.render_semaphore,
-		waitSemaphoreCount = 1,
-		pImageIndices      = &frame.swapchain_image_index,
-	}
-
+	// This will put the image we just rendered to into the visible window. we want to wait on
+	// the `ready_for_present_semaphore` for that, as its necessary that drawing commands
+	// have finished before the image is displayed to the user.
 	vk_check(vk.QueuePresentKHR(self.graphics_queue, &present_info)) or_return
 
 	// Increase the number of frames drawn

--- a/tutorial/02_drawing_with_compute/engine.odin
+++ b/tutorial/02_drawing_with_compute/engine.odin
@@ -341,6 +341,15 @@ engine_create_swapchain :: proc(self: ^Engine, width, height: u32) -> (ok: bool)
 	self.swapchain_images = vkb.swapchain_get_images(self.vkb.swapchain) or_return
 	self.swapchain_image_views = vkb.swapchain_get_image_views(self.vkb.swapchain) or_return
 	self.swapchain_image_semaphores = make([]vk.Semaphore, len(self.swapchain_images))[:]
+	defer if !ok do delete(self.swapchain_image_semaphores)
+
+	// These need to be created here so that they are recreated when we resize.
+	semaphore_create_info := semaphore_create_info()
+	for &semaphore in self.swapchain_image_semaphores {
+		vk_check(
+			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
+		) or_return
+	}
 
 	return true
 }
@@ -481,13 +490,6 @@ engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
 				nil,
 				&self.frames[i].swapchain_semaphore,
 			),
-		) or_return
-	}
-
-	// Create a semaphore for each image in the swapchain.
-	for &semaphore in self.swapchain_image_semaphores {
-		vk_check(
-			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
 		) or_return
 	}
 

--- a/tutorial/03_graphics_pipelines/drawing.odin
+++ b/tutorial/03_graphics_pipelines/drawing.odin
@@ -122,31 +122,32 @@ engine_draw :: proc(self: ^Engine) -> (ok: bool) {
 	// Finalize the command buffer (we can no longer add commands, but it can now be executed)
 	vk_check(vk.EndCommandBuffer(cmd)) or_return
 
-	// Prepare the submission to the queue. we want to wait on the
-	// `swapchain_semaphore`, as that semaphore is signaled when the swapchain is
-	// ready we will signal the `render_semaphore`, to signal that rendering has
-	// finished
+	// Prepare the submission to the queue. we want to wait on the `swapchain_semaphore`, as that
+	// semaphore is signaled when the swapchain is ready. We will signal the
+	// `ready_for_present_semaphore` to signal that rendering has finished.
+
+	ready_for_present_semaphore := self.swapchain_image_semaphores[frame.swapchain_image_index]
 
 	cmd_info := command_buffer_submit_info(cmd)
-	signal_info := semaphore_submit_info({.ALL_GRAPHICS}, frame.render_semaphore)
+	signal_info := semaphore_submit_info({.ALL_GRAPHICS}, ready_for_present_semaphore)
 	wait_info := semaphore_submit_info({.COLOR_ATTACHMENT_OUTPUT_KHR}, frame.swapchain_semaphore)
 
 	submit := submit_info(&cmd_info, &signal_info, &wait_info)
 
-	// Submit command buffer to the queue and execute it. _renderFence will now
-	// block until the graphic commands finish execution
+	// Submit command buffer to the queue and execute it. `render_fence` will now
+	// block until the graphic commands finish execution.
 	vk_check(vk.QueueSubmit2(self.graphics_queue, 1, &submit, frame.render_fence)) or_return
 
 	// Prepare present
 	//
-	// this will put the image we just rendered to into the visible window. we
-	// want to wait on the `render_semaphore` for that, as its necessary that
-	// drawing commands have finished before the image is displayed to the user
+	// This will put the image we just rendered to into the visible window. we want to wait on
+	// the `ready_for_present_semaphore` for that, as its necessary that drawing commands
+	// have finished before the image is displayed to the user.
 	present_info := vk.PresentInfoKHR {
 		sType              = .PRESENT_INFO_KHR,
 		pSwapchains        = &self.vk_swapchain,
 		swapchainCount     = 1,
-		pWaitSemaphores    = &frame.render_semaphore,
+		pWaitSemaphores    = &ready_for_present_semaphore,
 		waitSemaphoreCount = 1,
 		pImageIndices      = &frame.swapchain_image_index,
 	}

--- a/tutorial/03_graphics_pipelines/engine.odin
+++ b/tutorial/03_graphics_pipelines/engine.odin
@@ -18,7 +18,6 @@ Frame_Data :: struct {
 	command_pool:          vk.CommandPool,
 	main_command_buffer:   vk.CommandBuffer,
 	swapchain_semaphore:   vk.Semaphore,
-	render_semaphore:      vk.Semaphore,
 	swapchain_image_index: u32,
 	render_fence:          vk.Fence,
 	deletion_queue:        Deletion_Queue,
@@ -70,6 +69,7 @@ Engine :: struct {
 	swapchain_format:             vk.Format,
 	swapchain_images:             []vk.Image,
 	swapchain_image_views:        []vk.ImageView,
+	swapchain_image_semaphores:   []vk.Semaphore,
 
 	// Frame management
 	frames:                       [FRAME_OVERLAP]Frame_Data,

--- a/tutorial/03_graphics_pipelines/init.odin
+++ b/tutorial/03_graphics_pipelines/init.odin
@@ -268,6 +268,15 @@ engine_create_swapchain :: proc(self: ^Engine, width, height: u32) -> (ok: bool)
 	self.swapchain_images = vkb.swapchain_get_images(self.vkb.swapchain) or_return
 	self.swapchain_image_views = vkb.swapchain_get_image_views(self.vkb.swapchain) or_return
 	self.swapchain_image_semaphores = make([]vk.Semaphore, len(self.swapchain_images))[:]
+	defer if !ok do delete(self.swapchain_image_semaphores)
+
+	// These need to be created here so that they are recreated when we resize.
+	semaphore_create_info := semaphore_create_info()
+	for &semaphore in self.swapchain_image_semaphores {
+		vk_check(
+			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
+		) or_return
+	}
 
 	return true
 }
@@ -472,13 +481,6 @@ engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
 				nil,
 				&frame.swapchain_semaphore,
 			),
-		) or_return
-	}
-
-	// Create a semaphore for each image in the swapchain.
-	for &semaphore in self.swapchain_image_semaphores {
-		vk_check(
-			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
 		) or_return
 	}
 

--- a/tutorial/03_graphics_pipelines/init.odin
+++ b/tutorial/03_graphics_pipelines/init.odin
@@ -82,7 +82,6 @@ engine_cleanup :: proc(self: ^Engine) {
 
 		// Destroy sync objects
 		vk.DestroyFence(self.vk_device, frame.render_fence, nil)
-		vk.DestroySemaphore(self.vk_device, frame.render_semaphore, nil)
 		vk.DestroySemaphore(self.vk_device, frame.swapchain_semaphore, nil)
 
 		// Flush and destroy the peer frame deletion queue

--- a/tutorial/03_graphics_pipelines/init.odin
+++ b/tutorial/03_graphics_pipelines/init.odin
@@ -268,6 +268,7 @@ engine_create_swapchain :: proc(self: ^Engine, width, height: u32) -> (ok: bool)
 	self.swapchain_extent = swapchain.extent
 	self.swapchain_images = vkb.swapchain_get_images(self.vkb.swapchain) or_return
 	self.swapchain_image_views = vkb.swapchain_get_image_views(self.vkb.swapchain) or_return
+	self.swapchain_image_semaphores = make([]vk.Semaphore, len(self.swapchain_images))[:]
 
 	return true
 }
@@ -286,6 +287,12 @@ engine_resize_swapchain :: proc(self: ^Engine) -> (ok: bool) {
 engine_destroy_swapchain :: proc(self: ^Engine) {
 	vkb.destroy_swapchain(self.vkb.swapchain)
 	vkb.swapchain_destroy_image_views(self.vkb.swapchain, self.swapchain_image_views)
+
+	for semaphore in self.swapchain_image_semaphores {
+		vk.DestroySemaphore(self.vk_device, semaphore, nil)
+	}
+
+	delete(self.swapchain_image_semaphores)
 	delete(self.swapchain_image_views)
 	delete(self.swapchain_images)
 }
@@ -448,10 +455,9 @@ engine_init_commands :: proc(self: ^Engine) -> (ok: bool) {
 }
 
 engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
-	// Create synchronization structures, one fence to control when the gpu has
-	// finished rendering the frame, and 2 semaphores to sincronize rendering with
-	// swapchain. We want the fence to start signalled so we can wait on it on the
-	// first frame
+	// Create synchronization structures, one fence to control when the gpu has finished
+	// rendering the frame, and a semaphore to synchronize rendering with swapchain. We want
+	// the fence to start signaled so we can wait on it on the first frame.
 	fence_create_info := fence_create_info({.SIGNALED})
 	semaphore_create_info := semaphore_create_info()
 
@@ -468,13 +474,12 @@ engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
 				&frame.swapchain_semaphore,
 			),
 		) or_return
+	}
+
+	// Create a semaphore for each image in the swapchain.
+	for &semaphore in self.swapchain_image_semaphores {
 		vk_check(
-			vk.CreateSemaphore(
-				self.vk_device,
-				&semaphore_create_info,
-				nil,
-				&frame.render_semaphore,
-			),
+			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
 		) or_return
 	}
 

--- a/tutorial/04_textures_and_engine_architecture/drawing.odin
+++ b/tutorial/04_textures_and_engine_architecture/drawing.odin
@@ -123,31 +123,32 @@ engine_draw :: proc(self: ^Engine) -> (ok: bool) {
 	// Finalize the command buffer (we can no longer add commands, but it can now be executed)
 	vk_check(vk.EndCommandBuffer(cmd)) or_return
 
-	// Prepare the submission to the queue. we want to wait on the
-	// `swapchain_semaphore`, as that semaphore is signaled when the swapchain is
-	// ready we will signal the `render_semaphore`, to signal that rendering has
-	// finished
+	// Prepare the submission to the queue. we want to wait on the `swapchain_semaphore`, as that
+	// semaphore is signaled when the swapchain is ready. We will signal the
+	// `ready_for_present_semaphore` to signal that rendering has finished.
+
+	ready_for_present_semaphore := self.swapchain_image_semaphores[frame.swapchain_image_index]
 
 	cmd_info := command_buffer_submit_info(cmd)
-	signal_info := semaphore_submit_info({.ALL_GRAPHICS}, frame.render_semaphore)
+	signal_info := semaphore_submit_info({.ALL_GRAPHICS}, ready_for_present_semaphore)
 	wait_info := semaphore_submit_info({.COLOR_ATTACHMENT_OUTPUT_KHR}, frame.swapchain_semaphore)
 
 	submit := submit_info(&cmd_info, &signal_info, &wait_info)
 
-	// Submit command buffer to the queue and execute it. _renderFence will now
+	// Submit command buffer to the queue and execute it. `render_fence` will now
 	// block until the graphic commands finish execution
 	vk_check(vk.QueueSubmit2(self.graphics_queue, 1, &submit, frame.render_fence)) or_return
 
 	// Prepare present
 	//
-	// this will put the image we just rendered to into the visible window. we
-	// want to wait on the `render_semaphore` for that, as its necessary that
-	// drawing commands have finished before the image is displayed to the user
+	// This will put the image we just rendered to into the visible window. we want to wait on
+	// the `ready_for_present_semaphore` for that, as its necessary that drawing commands
+	// have finished before the image is displayed to the user.
 	present_info := vk.PresentInfoKHR {
 		sType              = .PRESENT_INFO_KHR,
 		pSwapchains        = &self.vk_swapchain,
 		swapchainCount     = 1,
-		pWaitSemaphores    = &frame.render_semaphore,
+		pWaitSemaphores    = &ready_for_present_semaphore,
 		waitSemaphoreCount = 1,
 		pImageIndices      = &frame.swapchain_image_index,
 	}

--- a/tutorial/04_textures_and_engine_architecture/engine.odin
+++ b/tutorial/04_textures_and_engine_architecture/engine.odin
@@ -19,7 +19,6 @@ Frame_Data :: struct {
 	command_pool:          vk.CommandPool,
 	main_command_buffer:   vk.CommandBuffer,
 	swapchain_semaphore:   vk.Semaphore,
-	render_semaphore:      vk.Semaphore,
 	swapchain_image_index: u32,
 	render_fence:          vk.Fence,
 	deletion_queue:        Deletion_Queue,
@@ -81,6 +80,7 @@ Engine :: struct {
 	swapchain_format:                 vk.Format,
 	swapchain_images:                 []vk.Image,
 	swapchain_image_views:            []vk.ImageView,
+	swapchain_image_semaphores:       []vk.Semaphore,
 
 	// Frame management
 	frames:                           [FRAME_OVERLAP]Frame_Data,

--- a/tutorial/04_textures_and_engine_architecture/init.odin
+++ b/tutorial/04_textures_and_engine_architecture/init.odin
@@ -89,7 +89,6 @@ engine_cleanup :: proc(self: ^Engine) {
 
 		// Destroy sync objects
 		vk.DestroyFence(self.vk_device, frame.render_fence, nil)
-		vk.DestroySemaphore(self.vk_device, frame.render_semaphore, nil)
 		vk.DestroySemaphore(self.vk_device, frame.swapchain_semaphore, nil)
 
 		// Flush and destroy the peer frame deletion queue

--- a/tutorial/05_scene_graph/engine.odin
+++ b/tutorial/05_scene_graph/engine.odin
@@ -19,7 +19,6 @@ Frame_Data :: struct {
 	command_pool:          vk.CommandPool,
 	main_command_buffer:   vk.CommandBuffer,
 	swapchain_semaphore:   vk.Semaphore,
-	render_semaphore:      vk.Semaphore,
 	swapchain_image_index: u32,
 	render_fence:          vk.Fence,
 	deletion_queue:        Deletion_Queue,
@@ -81,6 +80,7 @@ Engine :: struct {
 	swapchain_format:                 vk.Format,
 	swapchain_images:                 []vk.Image,
 	swapchain_image_views:            []vk.ImageView,
+	swapchain_image_semaphores:       []vk.Semaphore,
 
 	// Frame management
 	frames:                           [FRAME_OVERLAP]Frame_Data,

--- a/tutorial/05_scene_graph/init.odin
+++ b/tutorial/05_scene_graph/init.odin
@@ -93,7 +93,6 @@ engine_cleanup :: proc(self: ^Engine) {
 
 		// Destroy sync objects
 		vk.DestroyFence(self.vk_device, frame.render_fence, nil)
-		vk.DestroySemaphore(self.vk_device, frame.render_semaphore, nil)
 		vk.DestroySemaphore(self.vk_device, frame.swapchain_semaphore, nil)
 
 		// Flush and destroy the peer frame deletion queue

--- a/tutorial/05_scene_graph/init.odin
+++ b/tutorial/05_scene_graph/init.odin
@@ -273,6 +273,15 @@ engine_create_swapchain :: proc(self: ^Engine, width, height: u32) -> (ok: bool)
 	self.swapchain_images = vkb.swapchain_get_images(self.vkb.swapchain) or_return
 	self.swapchain_image_views = vkb.swapchain_get_image_views(self.vkb.swapchain) or_return
 	self.swapchain_image_semaphores = make([]vk.Semaphore, len(self.swapchain_images))[:]
+	defer if !ok do delete(self.swapchain_image_semaphores)
+
+	// These need to be created here so that they are recreated when we resize.
+	semaphore_create_info := semaphore_create_info()
+	for &semaphore in self.swapchain_image_semaphores {
+		vk_check(
+			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
+		) or_return
+	}
 
 	return true
 }
@@ -477,13 +486,6 @@ engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
 				nil,
 				&frame.swapchain_semaphore,
 			),
-		) or_return
-	}
-
-	// Create a semaphore for each image in the swapchain.
-	for &semaphore in self.swapchain_image_semaphores {
-		vk_check(
-			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
 		) or_return
 	}
 

--- a/tutorial/05_scene_graph/init.odin
+++ b/tutorial/05_scene_graph/init.odin
@@ -273,6 +273,7 @@ engine_create_swapchain :: proc(self: ^Engine, width, height: u32) -> (ok: bool)
 	self.swapchain_extent = swapchain.extent
 	self.swapchain_images = vkb.swapchain_get_images(self.vkb.swapchain) or_return
 	self.swapchain_image_views = vkb.swapchain_get_image_views(self.vkb.swapchain) or_return
+	self.swapchain_image_semaphores = make([]vk.Semaphore, len(self.swapchain_images))[:]
 
 	return true
 }
@@ -291,6 +292,12 @@ engine_resize_swapchain :: proc(self: ^Engine) -> (ok: bool) {
 engine_destroy_swapchain :: proc(self: ^Engine) {
 	vkb.destroy_swapchain(self.vkb.swapchain)
 	vkb.swapchain_destroy_image_views(self.vkb.swapchain, self.swapchain_image_views)
+
+	for semaphore in self.swapchain_image_semaphores {
+		vk.DestroySemaphore(self.vk_device, semaphore, nil)
+	}
+
+	delete(self.swapchain_image_semaphores)
 	delete(self.swapchain_image_views)
 	delete(self.swapchain_images)
 }
@@ -453,10 +460,9 @@ engine_init_commands :: proc(self: ^Engine) -> (ok: bool) {
 }
 
 engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
-	// Create synchronization structures, one fence to control when the gpu has
-	// finished rendering the frame, and 2 semaphores to sincronize rendering with
-	// swapchain. We want the fence to start signalled so we can wait on it on the
-	// first frame
+	// Create synchronization structures, one fence to control when the gpu has finished
+	// rendering the frame, and a semaphore to synchronize rendering with swapchain. We want
+	// the fence to start signaled so we can wait on it on the first frame.
 	fence_create_info := fence_create_info({.SIGNALED})
 	semaphore_create_info := semaphore_create_info()
 
@@ -473,13 +479,12 @@ engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
 				&frame.swapchain_semaphore,
 			),
 		) or_return
+	}
+
+	// Create a semaphore for each image in the swapchain.
+	for &semaphore in self.swapchain_image_semaphores {
 		vk_check(
-			vk.CreateSemaphore(
-				self.vk_device,
-				&semaphore_create_info,
-				nil,
-				&frame.render_semaphore,
-			),
+			vk.CreateSemaphore(self.vk_device, &semaphore_create_info, nil, &semaphore),
 		) or_return
 	}
 

--- a/website/docs/01_initializing-vulkan/06-mainloop-code.md
+++ b/website/docs/01_initializing-vulkan/06-mainloop-code.md
@@ -452,8 +452,8 @@ wait_info := semaphore_submit_info({.COLOR_ATTACHMENT_OUTPUT_KHR}, frame.swapcha
 
 submit := submit_info(&cmd_info, &signal_info, &wait_info)
 
-	// Submit command buffer to the queue and execute it. `render_fence` will now
-	// block until the graphic commands finish execution.
+// Submit command buffer to the queue and execute it. `render_fence` will now
+// block until the graphic commands finish execution.
 vk_check(vk.QueueSubmit2(self.graphics_queue, 1, &submit, frame.render_fence)) or_return
 ```
 

--- a/website/docs/01_initializing-vulkan/06-mainloop-code.md
+++ b/website/docs/01_initializing-vulkan/06-mainloop-code.md
@@ -11,21 +11,19 @@ need into our Frame_Data structure. We add the new members into the struct.
 ```odin
 Frame_Data :: struct {
     swapchain_semaphore:   vk.Semaphore,
-    render_semaphore:      vk.Semaphore,
     render_fence:          vk.Fence,
     swapchain_image_index: u32,
 }
 ```
 
-We are going to need 2 semaphores and the main render fence. Let us begin creating them.
+We are going to need a semaphore and the main render fence. Let us begin creating them.
 
 The `swapchain_semaphore` is going to be used so that our render commands wait on the swapchain
-image request. The `render_semaphore` will be used to control presenting the image to the OS
-once the drawing finishes `render_fence` will lets us wait for the draw commands of a given
+image request. `render_fence` will lets us wait for the draw commands of a given
 frame to be finished.
 
 Lets initialize them. Check the procedures to make a VkFenceCreateInfo and a
-VkSemaphoreCreateInfo on our vk_initializers.cpp code.
+VkSemaphoreCreateInfo on our initializers.odin code.
 
 ```odin title="tutorial/01_initializing_vulkan/initializers.odin"
 fence_create_info :: proc(flags: vk.FenceCreateFlags = {}) -> vk.FenceCreateInfo {
@@ -73,14 +71,6 @@ engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
                 &semaphore_create_info,
                 nil,
                 &frame.swapchain_semaphore,
-            ),
-        ) or_return
-        vk_check(
-            vk.CreateSemaphore(
-                self.vk_device,
-                &semaphore_create_info,
-                nil,
-                &frame.render_semaphore,
             ),
         ) or_return
     }
@@ -451,17 +441,19 @@ With the initializers made, we can write the submit itself.
 ```odin
 // Prepare the submission to the queue. we want to wait on the
 // `swapchain_semaphore`, as that semaphore is signaled when the swapchain is
-// ready we will signal the `render_semaphore`, to signal that rendering has
-// finished
+// ready. We will signal the `ready_for_present_semaphore`, to signal that
+// rendering has finished.
+
+ready_for_present_semaphore := self.swapchain_image_semaphores[frame.swapchain_image_index]
 
 cmd_info := command_buffer_submit_info(cmd)
-signal_info := semaphore_submit_info({.ALL_GRAPHICS}, frame.render_semaphore)
+signal_info := semaphore_submit_info({.ALL_GRAPHICS}, ready_for_present_semaphore)
 wait_info := semaphore_submit_info({.COLOR_ATTACHMENT_OUTPUT_KHR}, frame.swapchain_semaphore)
 
 submit := submit_info(&cmd_info, &signal_info, &wait_info)
 
-// Submit command buffer to the queue and execute it. _renderFence will now
-// block until the graphic commands finish execution
+	// Submit command buffer to the queue and execute it. `render_fence` will now
+	// block until the graphic commands finish execution.
 vk_check(vk.QueueSubmit2(self.graphics_queue, 1, &submit, frame.render_fence)) or_return
 ```
 
@@ -471,12 +463,12 @@ we are going to use the swapchain semaphore of the current frame. When we called
 `vk.AcquireNextImageKHR`, we set this same semaphore to be signaled, so with this, we make sure
 that the commands executed here wont begin until the swapchain image is ready.
 
-For signal info, we will be using the render_semaphore of the current frame, which will lets us
-syncronize with presenting the image on the screen.
+For signal info, we will be using the semaphore of the current swapchain image, which will lets us
+synchronize with presenting the image on the screen.
 
 And for the fence, we are going to use the current frame render_fence. At the start of the draw
-loop, we waited for that same fence to be ready. This is how we are going to syncronize our gpu
-to the cpu, as when the cpu goes ahead of the GPU, the fence will stop us so we dont use any of
+loop, we waited for that same fence to be ready. This is how we are going to synchronize our gpu
+to the cpu, as when the cpu goes ahead of the GPU, the fence will stop us so we don't use any of
 the other structures from this frame until the draw commands are executed.
 
 Last thing we need on the frame is to present the image we have just drawn into the screen
@@ -484,14 +476,14 @@ Last thing we need on the frame is to present the image we have just drawn into 
 ```odin
 // Prepare present
 //
-// this will put the image we just rendered to into the visible window. we
-// want to wait on the `render_semaphore` for that, as its necessary that
-// drawing commands have finished before the image is displayed to the user
+// This will put the image we just rendered to into the visible window. we want to wait on
+// the `ready_for_present_semaphore` for that, as its necessary that drawing commands
+// have finished before the image is displayed to the user.
 present_info := vk.PresentInfoKHR {
     sType              = .PRESENT_INFO_KHR,
     pSwapchains        = &self.vk_swapchain,
     swapchainCount     = 1,
-    pWaitSemaphores    = &frame.render_semaphore,
+    pWaitSemaphores    = &ready_for_present_semaphore,
     waitSemaphoreCount = 1,
     pImageIndices      = &frame.swapchain_image_index,
 }
@@ -504,7 +496,7 @@ self.frame_number += 1
 
 `vk.QueuePresent` has a very similar info struct as the queue submit. It also has the pointers
 for the semaphores, but it has image index and swapchain index. We will wait on the
-render_semaphore, and connect it to our swapchain. This way, we wont be presenting the image to
+ready_for_present_semaphore, and connect it to our swapchain. This way, we wont be presenting the image to
 the screen until it has finished the rendering commands from the submit right before it.
 
 At the end of the procedure, we increment frame counter.
@@ -518,7 +510,6 @@ for &frame in self.frames {
 
     // Destroy sync objects
     vk.DestroyFence(self.vk_device, frame.render_fence, nil)
-    vk.DestroySemaphore(self.vk_device, frame.render_semaphore, nil)
     vk.DestroySemaphore(self.vk_device, frame.swapchain_semaphore, nil)
 }
 ```
@@ -529,7 +520,7 @@ a flashing blue screen.
 ![Flashing blue screen](./img/section-1.jpg)
 
 If you encounter unexpected results, check the validation layers, as they will catch possible
-syncronization problems.
+synchronization problems.
 
 :::warning[]
 

--- a/website/docs/02-drawing-with-compute/01-improving-the-render-loop.md
+++ b/website/docs/02-drawing-with-compute/01-improving-the-render-loop.md
@@ -264,7 +264,6 @@ engine_cleanup :: proc(self: ^Engine) {
 
         // Destroy sync objects
         vk.DestroyFence(self.vk_device, frame.render_fence, nil)
-        vk.DestroySemaphore(self.vk_device, frame.render_semaphore, nil)
         vk.DestroySemaphore(self.vk_device, frame.swapchain_semaphore, nil)
 
         // Flush and destroy the peer frame deletion queue


### PR DESCRIPTION
This guide currently recommends using a second semaphore associated with each frame, as is suggested in the [original Vulkan guide](https://vkguide.dev/docs/new_chapter_1/vulkan_mainloop_code/). However, this appears to be a flawed approach that only happens to work in some environments on some drivers. The Vulkan docs have [a relevant page explaining the problem in detail](https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html).

A recent update to the Validation Layers has created a new error to catch semaphore re-use like this. Following this guide (or the original) will trigger the new warning:

<details>
<summary>Validation Layer Errors</summary>
<pre><code>
[INFO ] --- Entering main loop...
[ERROR] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkQueueSubmit2(): pSubmits[0].pSignalSemaphoreInfos[0].semaphore (VkSemaphore 0x160000000016) is being signaled by VkQueue 0x3f3530d0, but it may still be in use by VkSwapchainKHR 0x30000000003.
Here are the most recently acquired image indices: [0], 1, 2.
(brackets mark the last use of VkSemaphore 0x160000000016 in a presentation operation)
Swapchain image 0 was presented but was not re-acquired, so VkSemaphore 0x160000000016 may still be in use and cannot be safely reused with image index 2.
Vulkan insight: One solution is to assign each image its own semaphore. Here are some common methods to ensure that a semaphore passed to vkQueuePresentKHR is not in use and can be safely reused:
        a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
        b) Consider the VK_EXT_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.
The Vulkan spec states: The semaphore member of any binary semaphore element of the pSignalSemaphoreInfos member of any element of pSubmits must be unsignaled when the semaphore signal operation it defines is executed on the device (https://docs.vulkan.org/spec/latest/chapters/cmdbuffers.html#VUID-vkQueueSubmit
2-semaphore-03868)
[ERROR] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkQueueSubmit2(): pSubmits[0].pSignalSemaphoreInfos[0].semaphore (VkSemaphore 0x190000000019) is being signaled by VkQueue 0x3f3530d0, but it may still be in use by VkSwapchainKHR 0x30000000003.
Here are the most recently acquired image indices: 0, [1], 2, 3.
(brackets mark the last use of VkSemaphore 0x190000000019 in a presentation operation)
Swapchain image 1 was presented but was not re-acquired, so VkSemaphore 0x190000000019 may still be in use and cannot be safely reused with image index 3.
Vulkan insight: One solution is to assign each image its own semaphore. Here are some common methods to ensure that a semaphore passed to vkQueuePresentKHR is not in use and can be safely reused:
        a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
        b) Consider the VK_EXT_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.
The Vulkan spec states: The semaphore member of any binary semaphore element of the pSignalSemaphoreInfos member of any element of pSubmits must be unsignaled when the semaphore signal operation it defines is executed on the device (https://docs.vulkan.org/spec/latest/chapters/cmdbuffers.html#VUID-vkQueueSubmit
2-semaphore-03868)
[ERROR] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkQueueSubmit2(): pSubmits[0].pSignalSemaphoreInfos[0].semaphore (VkSemaphore 0x160000000016) is being signaled by VkQueue 0x3f3530d0, but it may still be in use by VkSwapchainKHR 0x30000000003.
Here are the most recently acquired image indices: 0, 1, [2], 3, 4.
(brackets mark the last use of VkSemaphore 0x160000000016 in a presentation operation)
Swapchain image 2 was presented but was not re-acquired, so VkSemaphore 0x160000000016 may still be in use and cannot be safely reused with image index 4.
Vulkan insight: One solution is to assign each image its own semaphore. Here are some common methods to ensure that a semaphore passed to vkQueuePresentKHR is not in use and can be safely reused:
        a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
        b) Consider the VK_EXT_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.
The Vulkan spec states: The semaphore member of any binary semaphore element of the pSignalSemaphoreInfos member of any element of pSubmits must be unsignaled when the semaphore signal operation it defines is executed on the device (https://docs.vulkan.org/spec/latest/chapters/cmdbuffers.html#VUID-vkQueueSubmit
2-semaphore-03868)
[ERROR] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkQueueSubmit2(): pSubmits[0].pSignalSemaphoreInfos[0].semaphore (VkSemaphore 0x190000000019) is being signaled by VkQueue 0x3f3530d0, but it may still be in use by VkSwapchainKHR 0x30000000003.
Here are the most recently acquired image indices: 0, 1, 2, [3], 4, 0.
(brackets mark the last use of VkSemaphore 0x190000000019 in a presentation operation)
Swapchain image 3 was presented but was not re-acquired, so VkSemaphore 0x190000000019 may still be in use and cannot be safely reused with image index 0.
Vulkan insight: One solution is to assign each image its own semaphore. Here are some common methods to ensure that a semaphore passed to vkQueuePresentKHR is not in use and can be safely reused:
        a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
        b) Consider the VK_EXT_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.
The Vulkan spec states: The semaphore member of any binary semaphore element of the pSignalSemaphoreInfos member of any element of pSubmits must be unsignaled when the semaphore signal operation it defines is executed on the device (https://docs.vulkan.org/spec/latest/chapters/cmdbuffers.html#VUID-vkQueueSubmit
2-semaphore-03868)
</code></pre>
</details>

The easiest fix is to use semaphores associated with the swapchain images, just as the Validation Layer error suggests. This PR implements the changes in all of the existing code so far, and updates the relevant documentation as well. Running the examples now should show no errors.

Note that this is implemented in the most straightforward way. I imagine it might be helpful to create a struct to manage the swapchain data rather than keep it spread out over 3 separate slices, or add a new helper methods to VKB to create & destroy the semaphores.