### PR TITLE
fix: rework window resize log

### DIFF
--- a/tutorial/03_graphics_pipelines/drawing.odin
+++ b/tutorial/03_graphics_pipelines/drawing.odin
@@ -27,16 +27,20 @@ engine_acquire_next_image :: proc(self: ^Engine) -> (ok: bool) {
 	vk_check(vk.ResetFences(self.vk_device, 1, &frame.render_fence)) or_return
 
 	// Request image from the swapchain
-	if result := vk.AcquireNextImageKHR(
+	result := vk.AcquireNextImageKHR(
 		self.vk_device,
 		self.vk_swapchain,
 		max(u64),
 		frame.swapchain_semaphore,
 		0,
 		&frame.swapchain_image_index,
-	); result == .ERROR_OUT_OF_DATE_KHR {
-		engine_resize_swapchain(self) or_return
+	)
+
+	// Just ignore these errors.
+	if result != .ERROR_OUT_OF_DATE_KHR && result != .SUBOPTIMAL_KHR {
+		vk_check(result) or_return
 	}
+
 
 	return true
 }
@@ -151,9 +155,12 @@ engine_draw :: proc(self: ^Engine) -> (ok: bool) {
 		pImageIndices      = &frame.swapchain_image_index,
 	}
 
-	if result := vk.QueuePresentKHR(self.graphics_queue, &present_info);
-	   result == .ERROR_OUT_OF_DATE_KHR {
+	result := vk.QueuePresentKHR(self.graphics_queue, &present_info)
+
+	if result == .ERROR_OUT_OF_DATE_KHR || result == .SUBOPTIMAL_KHR {
 		engine_resize_swapchain(self) or_return
+	} else {
+		vk_check(result) or_return
 	}
 
 	// Increase the number of frames drawn


### PR DESCRIPTION
Not every configuration or OS/Window System/Driver is guaranteed to return a `.ERROR_OUT_OF_DATE_KHR` error. For example, AMD drivers often return the `.SUBOPTIMAL_KHR` error instead.

Additionally, resizing the swapchain after acquiring the image, but before presenting it, appears to not be recommended (and gives me a lot of layer errors). The [Vulkan docs](https://docs.vulkan.org/tutorial/latest/03_Drawing_a_triangle/04_Swap_chain_recreation.html#_handling_resizes_explicitly) suggest only resizing the swapchain after presenting the image.

Those same docs also suggest setting a flag in the framebuffer resize callback and manually resizing at the beginning of the frame when that flag is set. However, when playing around with it, I found it to be unnecessary, so I haven't implemented it here.