### PR TITLE
fix: remove extra procedure declaration

### DIFF
--- a/website/docs/04-textures-and-engine-architecture/01-descriptor-abstractions.md
+++ b/website/docs/04-textures-and-engine-architecture/01-descriptor-abstractions.md
@@ -55,18 +55,6 @@ Descriptor_Allocator_Growable :: struct {
 descriptor_growable_init :: proc(
     self: ^Descriptor_Allocator_Growable,
     device: vk.Device,
-    initial_sets: u32,
-    pool_ratios: []Pool_Size_Ratio,
-    allocator := context.allocator,
-) -> (
-    ok: bool,
-) {
-    return
-}
-
-descriptor_growable_init :: proc(
-    self: ^Descriptor_Allocator_Growable,
-    device: vk.Device,
     max_sets: u32,
     pool_ratios: []Pool_Size_Ratio,
 ) -> (


### PR DESCRIPTION
The Descriptor Abstractions lesson has a duplicate declaration for the descriptor_growable_init procedure.