### PR TITLE
fix: remove extra wait in draw procedure

### DIFF
--- a/website/docs/04-textures-and-engine-architecture/05-meshes-and-camera.md
+++ b/website/docs/04-textures-and-engine-architecture/05-meshes-and-camera.md
@@ -407,9 +407,6 @@ engine_draw :: proc(self: ^Engine) -> (ok: bool) {
     // Other code bellow ---
 
     frame := engine_get_current_frame(self)
-
-    // Wait until the gpu has finished rendering the last frame. Timeout of 1 second
-    vk_check(vk.WaitForFences(self.vk_device, 1, &frame.render_fence, true, 1e9)) or_return
 }
 ```
 


### PR DESCRIPTION
The Meshes and Camera lesson shows a small section of the engine_draw procedure which includes a call to vk.WaitForFences. This call is not present in the actual code, as it's been moved to the acquire_next_image procedure.