### PR TITLE
fix: correct typo in improving the scene graph lesson

### DIFF
--- a/website/docs/05-scene-graph/01-improving-the-scene-graph.md
+++ b/website/docs/05-scene-graph/01-improving-the-scene-graph.md
@@ -512,7 +512,7 @@ scene_add_mesh_node :: proc(
 
     // Add name if provided
     if len(name) > 0 {
-        name_idx := append_and_get_id(&scene.node_names, name)
+        name_idx := append_and_get_idx(&scene.node_names, name)
         scene.name_for_node[u32(node)] = name_idx
     }
 


### PR DESCRIPTION
The lesson references a procedure called `append_and_get_id`. This was likely meant to be `append_and_get_idx`, as it appears in the code itself.