### PR TITLE
fix: add pool size ratio for combined_image_sampler

### DIFF
--- a/tutorial/04_textures_and_engine_architecture/init.odin
+++ b/tutorial/04_textures_and_engine_architecture/init.odin
@@ -494,7 +494,11 @@ engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
 
 engine_init_descriptors :: proc(self: ^Engine) -> (ok: bool) {
 	// Create a descriptor pool that will hold 10 sets with 1 image each
-	sizes := []Pool_Size_Ratio{{.STORAGE_IMAGE, 1}, {.UNIFORM_BUFFER, 1}}
+	sizes := []Pool_Size_Ratio {
+		{.STORAGE_IMAGE, 1},
+		{.UNIFORM_BUFFER, 1},
+		{.COMBINED_IMAGE_SAMPLER, 1},
+	}
 
 	descriptor_allocator_init_pool(
 		&self.global_descriptor_allocator,

--- a/tutorial/05_scene_graph/init.odin
+++ b/tutorial/05_scene_graph/init.odin
@@ -492,7 +492,11 @@ engine_init_sync_structures :: proc(self: ^Engine) -> (ok: bool) {
 
 engine_init_descriptors :: proc(self: ^Engine) -> (ok: bool) {
 	// Create a descriptor pool that will hold 10 sets with 1 image each
-	sizes := []Pool_Size_Ratio{{.STORAGE_IMAGE, 1}, {.UNIFORM_BUFFER, 1}}
+	sizes := []Pool_Size_Ratio {
+		{.STORAGE_IMAGE, 1},
+		{.UNIFORM_BUFFER, 1},
+		{.COMBINED_IMAGE_SAMPLER, 1},
+	}
 
 	descriptor_allocator_init_pool(
 		&self.global_descriptor_allocator,


### PR DESCRIPTION
The `engine_init_descriptors` implementation doesn't include a pool size ratio for `COMBINED_IMAGE_SAMPLER` descriptors. As-is, running the application will trigger a layer validation warning:

<details>
<summary>Validation Layer Warnings</summary>
<pre style="white-space: pre-wrap"><code>
[WARN ] --- [DebugUtilsMessageTypeFlagsEXT{VALIDATION}]: vkAllocateDescriptorSets():
pAllocateInfo->pSetLayouts[0] binding 1 was created with
VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER but VkDescriptorPool
0x1d000000001d was not created with any VkDescriptorPoolSize::type with
VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER (Some implementations will not
VK_ERROR_OUT_OF_POOL_MEMORY as they should with VK_KHR_maintenance1).
</code></pre>
</details>

This is because the Descriptor Pool was created without without a size for the `COMBINED_IMAGE_SAMPLER` descriptor type. Adding that back in makes the error go away.